### PR TITLE
Create multiple overloads instead of one that returns 10 values

### DIFF
--- a/or_return.jai
+++ b/or_return.jai
@@ -29,53 +29,8 @@ default_of_type_as_string :: (ti: *Type_Info) -> string {
 }
 
 // TODO: We're completely disrespecting #must here. There's no way to set #must in modify, so we need to improve our message loop
-or_return :: ($code: Code, $outer_proc_header: Code = (#code dummy), $declared_named_returns: ..string) -> $T1, $T2, $T3, $T4, $T5, $T6, $T7, $T8, $T9, $T10 #expand 
-#modify {
-    root, expressions := Compiler.compiler_get_nodes(code);
-    if root.kind != .PROCEDURE_CALL {
-        return false, "or_return macro only supports procedure_calls";
-    }
-
-    call := cast(*Compiler.Code_Procedure_Call)root;
-    proc_expr := call.resolved_procedure_expression;
-
-    if proc_expr.kind != .PROCEDURE_HEADER {
-        return false, "Unexpected resolved procedure expression";
-    }
-
-    header := cast(*Compiler.Code_Procedure_Header)proc_expr;
-
-    return_values := header.returns.count;
-    if return_values < 1 {
-        return false, tprint("Procedure should have at least a single return value, but it has %", return_values);
-    }
-
-    last_return := header.returns[return_values-1].type_inst;
-    last_return_type := Compiler.get_type(last_return.result);
-    ti := cast(*Type_Info)last_return_type;
-    if ti.type == .STRUCT {
-        return false, tprint("The last return value of the procedure `%` passed to or_return is a struct `%`.\nStructs can't be evaluated as booleans, so or_return doesn't support them.", header.name, last_return_type);
-    }
-
-    T1, T2, T3, T4, T5, T6, T7, T8, T9, T10 = bool;
-    for 0..return_values - 1 {
-        return_ := header.returns[it].type_inst;
-        return_type := Compiler.get_type(return_.result);
-        if it == 0 T1  = return_type;
-        if it == 1 T2  = return_type;
-        if it == 2 T3  = return_type;
-        if it == 3 T4  = return_type;
-        if it == 4 T5  = return_type;
-        if it == 5 T6  = return_type;
-        if it == 6 T7  = return_type;
-        if it == 7 T8  = return_type;
-        if it == 8 T9  = return_type;
-        if it == 9 T10 = return_type;
-    }
-    return true;
-}
-{
-    #insert,scope(code) -> string {
+or_return_inner :: ($code_returns: int, $code: Code, $outer_proc_header: Code = (#code dummy), $declared_named_returns: ..string) -> string #expand {
+    return #run -> string {
         root, expressions := Compiler.compiler_get_nodes(code);
 
         outer := Compiler.compiler_get_nodes(outer_proc_header);
@@ -158,16 +113,13 @@ or_return :: ($code: Code, $outer_proc_header: Code = (#code dummy), $declared_n
                 append(*builder, ", ");
             }
         }
-        for 0..10-count-1 {
-            append(*builder, ", false");
-        }
         append(*builder, ";");
         append(*builder, "\n}\n");
 
         result_code := builder_to_string(*builder);
 
         return result_code;
-    }
+    };
 }
 
 #scope_file

--- a/or_return_build.jai
+++ b/or_return_build.jai
@@ -1,32 +1,35 @@
-or_return_build :: () {
-    w := compiler_create_workspace("or_return workspace");
-    if !w {
-        print("Workspace creation failed.\n");
-        return;
+or_return_build :: (w: Workspace) {
+
+    for 1..10 {
+        returns_array: [..]string;
+        defaults_array: [..]string;
+        designators_array: [..]string;
+        returns: string;
+        defaults: string;
+        designators: string;
+
+        for 1..it {
+            array_add(*returns_array, tprint("$T%", it));
+            array_add(*defaults_array, tprint("T%", it));
+            array_add(*designators_array, tprint("if it == % T% = return_type;", it - 1, it));
+        }
+        returns = join(..returns_array, ", ");
+        defaults = tprint("% = bool;", join(..defaults_array, ", "));
+        designators = join(..designators_array, "\n        ");
+        add_build_string(tprint(OR_RETURN_TEMPLATE, returns, defaults, designators, it), w);
     }
 
-    compiler_begin_intercept(w);
-
     message_loop();
-
-    compiler_end_intercept(w);
 }
-
 
 message_loop :: () {
     while true {
         message := compiler_wait_for_message();
         if message.kind == {
         case .TYPECHECKED;
-
             typechecked := cast(*Message_Typechecked) message;
             handle_typechecked(typechecked);
 
-            
-        case .PHASE;
-            phase := cast(*Message_Phase) message;
-            if phase.phase == .TYPECHECKED_ALL_WE_CAN {}
-            
         case .COMPLETE;
             break;
         }
@@ -69,9 +72,9 @@ handle_typechecked :: (typechecked: *Message_Typechecked) {
                     continue;
                 }
 
-                shit := cast(*Code_Compound_Declaration)statement;
                 or_return_call_args: [..]Code_Argument;
-                array_add(*or_return_call_args, call.arguments_unsorted[0]);
+                first_arg := call.arguments_unsorted[0];
+                array_add(*or_return_call_args, first_arg);
 
                 {
 
@@ -103,8 +106,55 @@ handle_typechecked :: (typechecked: *Message_Typechecked) {
     }
 }
 
+OR_RETURN_TEMPLATE :: #string DONE_FR
+or_return :: ($code: Code, $outer_proc_header: Code = (#code dummy), $declared_named_returns: ..string) -> %1 #expand
+#modify {
+    root, expressions := Compiler.compiler_get_nodes(code);
+    if root.kind != .PROCEDURE_CALL {
+        return false, "or_return macro only supports procedure_calls";
+    }
+
+    call := cast(*Compiler.Code_Procedure_Call)root;
+    proc_expr := call.resolved_procedure_expression;
+
+    if proc_expr.kind != .PROCEDURE_HEADER {
+        return false, "Unexpected resolved procedure expression";
+    }
+
+    header := cast(*Compiler.Code_Procedure_Header)proc_expr;
+
+    return_values := header.returns.count;
+    if return_values != %4 {
+        return false, tprint("Procedure should have exactly %% return values, but it has %%", %4, return_values);
+    }
+
+    last_return := header.returns[return_values-1].type_inst;
+    last_return_type := Compiler.get_type(last_return.result);
+    ti := cast(*Type_Info)last_return_type;
+    if ti.type == .STRUCT {
+        return false, tprint("The last return value of the procedure `%%` passed to or_return is a struct `%%`.\nStructs can't be evaluated as booleans, so or_return doesn't support them.", header.name, last_return_type);
+    }
+
+    %2
+
+    for 0..return_values - 1 {
+        return_ := header.returns[it].type_inst;
+        return_type := Compiler.get_type(return_.result);
+        %3
+    }
+
+    return true;
+} {
+    #insert,scope(code) -> string {
+        return or_return_inner(%4, code, outer_proc_header, ..declared_named_returns);
+    }
+}
+
+DONE_FR
+
 #scope_file
 
 #import "Basic";
 #import "Compiler";
 #import "Code_Visit";
+#import "String";

--- a/or_return_build.jai
+++ b/or_return_build.jai
@@ -1,34 +1,14 @@
+// You can call this if your build script doesn't have a custom message loop
+// Call this after compiler_begin_intercept and after adding your build file
 or_return_build :: (w: Workspace) {
+    or_return_add_source(w);
 
-    for 1..10 {
-        returns_array: [..]string;
-        defaults_array: [..]string;
-        designators_array: [..]string;
-        returns: string;
-        defaults: string;
-        designators: string;
-
-        for 1..it {
-            array_add(*returns_array, tprint("$T%", it));
-            array_add(*defaults_array, tprint("T%", it));
-            array_add(*designators_array, tprint("if it == % T% = return_type;", it - 1, it));
-        }
-        returns = join(..returns_array, ", ");
-        defaults = tprint("% = bool;", join(..defaults_array, ", "));
-        designators = join(..designators_array, "\n        ");
-        add_build_string(tprint(OR_RETURN_TEMPLATE, returns, defaults, designators, it), w);
-    }
-
-    message_loop();
-}
-
-message_loop :: () {
     while true {
         message := compiler_wait_for_message();
         if message.kind == {
         case .TYPECHECKED;
             typechecked := cast(*Message_Typechecked) message;
-            handle_typechecked(typechecked);
+            or_return_handle_typechecked(typechecked);
 
         case .COMPLETE;
             break;
@@ -36,7 +16,8 @@ message_loop :: () {
     }
 }
 
-handle_typechecked :: (typechecked: *Message_Typechecked) {
+// Call this inside of your metaprogram loop.
+or_return_handle_typechecked :: (typechecked: *Message_Typechecked) {
     for to: typechecked.procedure_bodies {
         body := to.expression;
         if body.body_flags & .ALREADY_MODIFIED {
@@ -151,6 +132,63 @@ or_return :: ($code: Code, $outer_proc_header: Code = (#code dummy), $declared_n
 }
 
 DONE_FR
+
+or_return_add_source :: (w: Workspace) {
+    for 1..10 {
+        returns_array: [..]string;
+        defaults_array: [..]string;
+        designators_array: [..]string;
+        returns: string;
+        defaults: string;
+        designators: string;
+
+        for 1..it {
+            array_add(*returns_array, tprint("$T%", it));
+            array_add(*defaults_array, tprint("T%", it));
+            array_add(*designators_array, tprint("if it == % T% = return_type;", it - 1, it));
+        }
+        returns = join(..returns_array, ", ");
+        defaults = tprint("% = bool;", join(..defaults_array, ", "));
+        designators = join(..designators_array, "\n        ");
+        add_build_string(tprint(OR_RETURN_TEMPLATE, returns, defaults, designators, it), w);
+    }
+    add_build_string("Compiler :: #import \"Compiler\";", w);
+}
+
+// Experimental metaprogram plugin, ignore this for now.
+add_source :: (p: *Metaprogram_Plugin)  {
+    plugin := cast(*Or_Return_Plugin) p;
+    w := p.workspace;
+    assert(w >= 0);
+
+    inline or_return_add_source(w);
+}
+
+message :: (p: *Metaprogram_Plugin, message: *Message) {
+    plugin := cast(*Or_Return_Plugin) p;
+
+    if message.kind != .TYPECHECKED return;
+
+    typechecked := cast(*Message_Typechecked) message;
+    inline or_return_handle_typechecked(typechecked);
+}
+
+shutdown :: (p: *Metaprogram_Plugin) {
+    free(p);
+}
+
+get_plugin :: () -> *Metaprogram_Plugin {
+    p := New(Or_Return_Plugin);
+    p.add_source = add_source;
+    p.message = message;
+    p.shutdown = shutdown;
+
+    return p;
+}
+
+Or_Return_Plugin :: struct {
+    #as using base: Metaprogram_Plugin;
+}
 
 #scope_file
 

--- a/tests/build.jai
+++ b/tests/build.jai
@@ -15,7 +15,7 @@ build :: () {
 
     add_build_file("./tests.jai",  w);
 
-    or_return_build();
+    or_return_build(w);
     compiler_end_intercept(w);
 
     set_build_options_dc(.{do_output=false});

--- a/tests/tests.jai
+++ b/tests/tests.jai
@@ -150,5 +150,3 @@ returns_struct :: () -> Res1 {
 
 
 #import "Basic";
-#import "Compiler";
-#import "Print_Vars";


### PR DESCRIPTION
Generate multiple `or_return` headers instead of one amalgamated that returns 10 things. It has better runtime characteristics, and has a funny property of letting a user to control up to how many returns `or_return` could support. And it doesn't look like it affects compile times in any way. But it's obviously harder to understand, because it uses a string template to generate headers, because it doesn't look like we have a way to do this directly in a metaprogram loop. 

I want to let it boil for a bit before merging it.